### PR TITLE
Add support for devices with multiple PID/PID

### DIFF
--- a/microtvm_device/device_client.py
+++ b/microtvm_device/device_client.py
@@ -45,7 +45,7 @@ class GRPCMicroDevice:
     def __init__(self, ip: str, port: int, device_type: str):
         self._rpc_channel = grpc.insecure_channel(f"{ip}:{port}")
         self._rpc_stub = microDevice_pb2_grpc.RPCRequestStub(self._rpc_channel)
-        self._device = MicroDevice(type=device_type, serial_number="")
+        self._device = MicroDevice(device_type=device_type, serial_number="")
 
         # Request session number
         response = self._rpc_stub.RPCSessionRequest(

--- a/microtvm_device/device_utils.py
+++ b/microtvm_device/device_utils.py
@@ -43,7 +43,7 @@ class MicroDevice(object):
     """A microTVM device instance."""
 
     def __init__(
-        self, type: str, serial_number: str, vid_hex: str = None, pid_hex: str = None
+        self, device_type: str, serial_number: str, vid_hex: str = None, pid_hex: str = None
     ) -> None:
         """
         Parameters
@@ -63,13 +63,13 @@ class MicroDevice(object):
         _enabled : bool
             True if device is enabled to use.
         """
-        self._type = type
-        self._serial_number = serial_number
-        self._vid_hex = vid_hex
-        self._pid_hex = pid_hex
-        self._is_taken = False
-        self._user = None
-        self._enabled = True
+        self._type: str = device_type
+        self._serial_number: str = serial_number
+        self._vid_hex: str = vid_hex
+        self._pid_hex: str = pid_hex
+        self._is_taken: bool = False
+        self._user: str = None
+        self._enabled: bool = True
         super().__init__()
 
     def __str__(self) -> str:
@@ -238,13 +238,14 @@ def LoadDeviceTable(table_file: str) -> MicroTVMPlatforms:
         device_table = MicroTVMPlatforms()
         for device_type, config in data.items():
             for item in config["instances"]:
-                new_device = MicroDevice(
-                    type=device_type,
-                    serial_number=item,
-                    vid_hex=config["vid_hex"],
-                    pid_hex=config["pid_hex"],
-                )
-                device_table.AddPlatform(new_device)
+                for (vid, pid) in config["vid_pid_hex"]:
+                    new_device = MicroDevice(
+                        device_type=device_type,
+                        serial_number=item,
+                        vid_hex=vid,
+                        pid_hex=pid,
+                    )
+                    device_table.AddPlatform(new_device)
     return device_table
 
 
@@ -363,7 +364,7 @@ def ListConnectedDevices(micro_device: MicroDevice) -> list:
     device_list = []
     for device in devices:
         new_device = MicroDevice(
-            type=micro_device.GetType(),
+            device_type=micro_device.GetType(),
             serial_number=device["SerialNumber"],
             vid_hex=micro_device.GetVID(),
             pid_hex=micro_device.GetPID(),
@@ -441,7 +442,7 @@ def virtualbox_is_live(machine_uuid: str):
 
 
 def attach_command(args):
-    attach(MicroDevice(type=args.microtvm_platform, serial_number=args.serial), args.vm_path)
+    attach(MicroDevice(device_type=args.microtvm_platform, serial_number=args.serial), args.vm_path)
 
 
 def attach(micro_device: MicroDevice, vm_path: str):

--- a/tests/config/device_table.template.json
+++ b/tests/config/device_table.template.json
@@ -1,7 +1,6 @@
 {
     "nucleo_f746zg": {
-        "vid_hex": "0483",
-        "pid_hex": "374b",
+        "vid_pid_hex": [["0483","374b"]],
         "manufacturer": "STMicroelectronics",
         "instances": [
             "nucleo_f746zg_1",
@@ -10,8 +9,7 @@
         ]
         },
     "stm32f746g_disco": {
-        "vid_hex": "0483",
-        "pid_hex": "374b",
+        "vid_pid_hex": [["0483", "374b"]],
         "manufacturer": "STMicroelectronics",
         "instances": [
             "stm32f746g_disco_1",
@@ -20,8 +18,7 @@
         ]
     },
     "nrf5340dk_nrf5340_cpuapp": {
-        "vid_hex": "1366",
-        "pid_hex": "1055",
+        "vid_pid_hex": [["1366", "1051"], ["1366", "1055"]],
         "manufacturer": "SEGGER",
         "instances": [
             "nrf5340dk_nrf5340_cpuapp_1",
@@ -45,43 +42,12 @@
         ]
     },
     "nucleo_l4r5zi": {
-        "vid_hex": "0483",
-        "pid_hex": "374b",
+        "vid_pid_hex": [["0483", "374b"]],
         "manufacturer": "STMicroelectronics",
         "instances": [
             "nucleo_l4r5zi_1",
             "nucleo_l4r5zi_2",
             "nucleo_l4r5zi_3"
-        ]
-    },
-    "nano33ble": {
-        "vid_hex": "2341",
-        "pid_hex": "805a",
-        "manufacturer": "NA",
-        "instances": [
-            "nano33ble_1",
-            "nano33ble_2",
-            "nano33ble_3"
-        ]
-    },
-    "due": {
-        "vid_hex": "2341",
-        "pid_hex": "003d",
-        "manufacturer": "NA",
-        "instances": [
-            "due_1",
-            "due_2",
-            "due_3"
-        ]
-    },
-    "spresense": {
-        "vid_hex": "10c4",
-        "pid_hex": "ea60",
-        "manufacturer": "NA",
-        "instances": [
-            "spresense_1",
-            "spresense_2",
-            "spresense_3"
         ]
     }
 }


### PR DESCRIPTION
There are cases where the same device like nrf5340dk_nrf5340_cpuapp releases with different development kit where they have different PID numbers. We would like to have all boards like this in the same category. This PR moves VID and PID separate items in the device table json as list of variations like `[[VID1, PID1], [VID2, PID2], [VID1, PID3]]` to support more generic case.