### PR TITLE
Fix multiple PID bug

### DIFF
--- a/microtvm_device/device_server.py
+++ b/microtvm_device/device_server.py
@@ -41,7 +41,7 @@ def LoadAttachedDevices(args: argparse.Namespace) -> MicroTVMPlatforms:
 
     return: attached_devices
     """
-    table = device_utils.LoadDeviceTable(args.table_file)
+    table: MicroTVMPlatforms = device_utils.LoadDeviceTable(args.table_file)
 
     # Return a fake list of devices for testing
     if args.dry_run:

--- a/microtvm_device/device_utils.py
+++ b/microtvm_device/device_utils.py
@@ -211,8 +211,9 @@ class MicroTVMPlatforms:
         micro_device_list = list()
         all_types = set()
         for platform in self._platforms:
-            if platform.GetType() not in all_types:
-                all_types.add(platform.GetType())
+            platform_code = f"{platform.GetType()},{platform.GetPID()},{platform.GetVID()}"
+            if platform_code not in all_types:
+                all_types.add(platform_code)
                 micro_device_list.append(platform)
         return micro_device_list
 
@@ -237,15 +238,14 @@ def LoadDeviceTable(table_file: str) -> MicroTVMPlatforms:
         data = json.load(json_f)
         device_table = MicroTVMPlatforms()
         for device_type, config in data.items():
-            for item in config["instances"]:
-                for (vid, pid) in config["vid_pid_hex"]:
-                    new_device = MicroDevice(
-                        device_type=device_type,
-                        serial_number=item,
-                        vid_hex=vid,
-                        pid_hex=pid,
-                    )
-                    device_table.AddPlatform(new_device)
+            for (serial, vid, pid) in config["instances"]:
+                new_device = MicroDevice(
+                    device_type=device_type,
+                    serial_number=serial,
+                    vid_hex=vid,
+                    pid_hex=pid,
+                )
+                device_table.AddPlatform(new_device)
     return device_table
 
 

--- a/tests/config/device_table.template.json
+++ b/tests/config/device_table.template.json
@@ -1,53 +1,27 @@
 {
     "nucleo_f746zg": {
-        "vid_pid_hex": [["0483","374b"]],
         "manufacturer": "STMicroelectronics",
         "instances": [
-            "nucleo_f746zg_1",
-            "nucleo_f746zg_2",
-            "nucleo_f746zg_3"
+            ["nucleo_f746zg_1",,"0483","374b"]
         ]
         },
     "stm32f746g_disco": {
-        "vid_pid_hex": [["0483", "374b"]],
         "manufacturer": "STMicroelectronics",
         "instances": [
-            "stm32f746g_disco_1",
-            "stm32f746g_disco_2",
-            "stm32f746g_disco_3"
+            ["stm32f746g_disco_1","0483","374b"]
         ]
     },
     "nrf5340dk_nrf5340_cpuapp": {
-        "vid_pid_hex": [["1366", "1051"], ["1366", "1055"]],
         "manufacturer": "SEGGER",
         "instances": [
-            "nrf5340dk_nrf5340_cpuapp_1",
-            "nrf5340dk_nrf5340_cpuapp_2",
-            "nrf5340dk_nrf5340_cpuapp_3",
-            "nrf5340dk_nrf5340_cpuapp_4",
-            "nrf5340dk_nrf5340_cpuapp_5",
-            "nrf5340dk_nrf5340_cpuapp_6",
-            "nrf5340dk_nrf5340_cpuapp_7",
-            "nrf5340dk_nrf5340_cpuapp_8",
-            "nrf5340dk_nrf5340_cpuapp_9",
-            "nrf5340dk_nrf5340_cpuapp_10",
-            "nrf5340dk_nrf5340_cpuapp_11",
-            "nrf5340dk_nrf5340_cpuapp_12",
-            "nrf5340dk_nrf5340_cpuapp_13",
-            "nrf5340dk_nrf5340_cpuapp_14",
-            "nrf5340dk_nrf5340_cpuapp_15",
-            "nrf5340dk_nrf5340_cpuapp_16",
-            "nrf5340dk_nrf5340_cpuapp_17",
-            "nrf5340dk_nrf5340_cpuapp_18"
+            ["nrf5340dk_nrf5340_cpuapp_1","1366","1051"],
+            ["nrf5340dk_nrf5340_cpuapp_2","1366","1055"]
         ]
     },
     "nucleo_l4r5zi": {
-        "vid_pid_hex": [["0483", "374b"]],
         "manufacturer": "STMicroelectronics",
         "instances": [
-            "nucleo_l4r5zi_1",
-            "nucleo_l4r5zi_2",
-            "nucleo_l4r5zi_3"
+            ["nucleo_l4r5zi_1","0483","374b"]
         ]
     }
 }


### PR DESCRIPTION
#11 change has a bug where the initial device table overrides one device with serial number A, with only on PID number. Therefore, I changed the table format to have instances like `serial, vid, pid` value in the list to make sure each item with it's unique PID is added to table